### PR TITLE
Override the form submission with ajax

### DIFF
--- a/stream/src/css/style.css
+++ b/stream/src/css/style.css
@@ -33,7 +33,7 @@ label, legend {
 .btn-primary:hover {
   background-color: #ef4134;
 }
-.btn-info {
+.btn-info, .btn-warning {
   color: #272f32;
 }
 .btn {
@@ -132,3 +132,104 @@ h4 {
 }
 
 
+
+
+/* Action Kit Errors
+   ========================================================================== */
+
+/* Error and confirmation blocks */
+/* csslint ignore:start */
+#ak-errors,
+#ak-confirmation,
+#ak-error-info,
+.ak-errors,
+.ak-confirmation,
+.ak-error-info {
+    display: none
+}
+
+form.contains-errors #ak-errors,
+form.contains-errors #ak-error-info,
+form.contains-errors .ak-errors,
+form.contains-errors .ak-error-info {
+    display: block;
+}
+
+#ak-errors,
+#ak-confirmation,
+.ak-errors,
+.ak-confirmation {
+    list-style-type: none;
+    font-weight: 200;
+    padding: 7px 12px;
+    margin: 7px 0;
+}
+
+ul#ak-errors li,
+ul.ak-errors li {
+    padding: 0;
+    margin: 0;
+}
+
+.ak-color-error {
+    color: #d00;
+}
+
+#ak-errors,
+.ak-errors {
+    background-color: #ffe6e6;
+    color: #ef4134;
+    font-weight: 200;
+}
+#ak-confirmation,
+.ak-confirmation {
+    background-color: #668d24;
+    color: #fff;
+    font-weight: 400;
+}
+
+/* Fields with error conditions */
+.ak-styled-fields input[type="text"].ak-error,
+.ak-styled-fields input[type="password"].ak-error,
+.ak-styled-fields input[type="number"].ak-error,
+.ak-styled-fields input[type="email"].ak-error,
+.ak-styled-fields textarea.ak-error,
+.ak-styled-fields select.ak-error,
+input.ak-error,
+select.ak-error,
+textarea.ak-error {
+    background-color: #ffe6e6;
+    border-color: #d00;
+}
+
+span.ak-error,
+label.ak-error,
+.ak-labels-overlaid input.ak-error,
+.ak-labels-overlaid label.ak-error,
+.ak-labels-before label.ak-error,
+.ak-styled-fields select.ak-error {
+    color: #d00;
+    font-weight: 600;
+}
+
+/* Inline errors */
+.ak-err {
+    color: #d00;
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+
+.ak-err li {
+    line-height: 1.4;
+}
+
+.ak-err-above .ak-err {
+    margin-top: 0.25em;
+}
+.ak-err-below .ak-err {
+    margin-top: -4px;
+    margin-bottom: 12px;
+}
+
+/* csslint ignore:end */

--- a/stream/src/index.html
+++ b/stream/src/index.html
@@ -28,7 +28,7 @@
                         <div class="row">
                             <div class="col-xs-12 col-sm-12 form-group">
                                 <label for="email">Email</label>
-                                <input id="email" class="form-control" type="email" name="email" placeholder="Email" required />
+                                <input id="email" class="form-control" type="text" name="email" placeholder="Email" required />
                             </div>
                         </div>
                         <div class="row">
@@ -48,7 +48,7 @@
                             </div>
                             <div class="col-xs-6 col-sm-12 col-md-6 form-group">
                                 <label for="phone-number">Phone Number</label>
-                                <input id="phone-number" class="form-control" type="tel" name="mobile_phone" placeholder="Phone Number" required />
+                                <input id="phone-number" class="form-control" type="text" name="mobile_phone" placeholder="Phone Number" required />
                             </div>
                         </div>
                         <div class="row">

--- a/stream/src/js/stream.js
+++ b/stream/src/js/stream.js
@@ -1,10 +1,59 @@
 $(document).ready(function() {
+    actionkit.forms.contextRoot = 'https://go.peoplepower.org/context/';
+    actionkit.forms.initPage();
+    actionkit.forms.initForm('act');
+
+    // I'll admit. Not the cleanest way but it'll work!
+    $('#signup-form').submit(function(e) {
+        var form = $(e.target);
+
+        var handler = function(form, success) {
+            if (success) {
+                // Let user know that it's done
+                form.find('input.btn').addClass('btn-success').val('Successfully Submitted!');
+                setTimeout(function() {
+                    form.find('input.btn').removeClass('btn-success').addClass('btn-primary').val('SIGN UP');
+                }, 5000);
+                // Reset the form for next submission
+                form.trigger('reset');
+            } else {
+                // Let user know that it failed
+                // Keep the form as is for resubmission
+                form.find('input.btn').addClass('btn-warning').val('Error. Try again?');
+                setTimeout(function() {
+                    form.find('input.btn').removeClass('btn-warning').addClass('btn-primary').val('SIGN UP');
+                }, 5000);
+            }
+        };
+
+        if (!form.hasClass('contains-errors')) {
+            e.preventDefault();
+            form.find('input.btn').removeClass('btn-primary').val('Submitting...');
+            $.ajax({
+                type: "POST",
+                url: form.attr('action'),
+                data: form.serialize(),
+                dataType: "jsonp",
+                success: function(data, textStatus, jqXHR) {
+                    if (data.result == "success") {
+                        // Form submitted!
+                        handler(form, true);
+                    } else {
+                        // Handle error
+                        handler(form, false);
+                    }
+                },
+                error: function(jqXHR, textStatus, errorThrown) {
+                    // Handle error
+                    handler(form, false);
+                }
+            });
+        }
+    });
+
     $('#video').on('click', function() {
         /* TODO: Correct video URL */
         $(this).html('<div class="video-background"><iframe title="Live Stream Video" src="https://www.youtube.com/embed/e2axToBYD68?autoplay=1" allowfullscreen></iframe></div>');
     });
 
-    actionkit.forms.contextRoot = 'https://go.peoplepower.org/context/';
-    actionkit.forms.initPage();
-    actionkit.forms.initForm('act');
 });


### PR DESCRIPTION
Ideally we'd like to use https://roboticdogs.actionkit.com/docs/manual/guide/page_tools.html#ajax-signup-widget but since as a volunteer, we don't have access to actionkit and are basically reverse engineering, this is the best route forward.

Basically, let ActionKit do the validation. Then when it validates, intercept the POST request and just do it via AJAX and JSONP.

This one you should try in person: https://s3.amazonaws.com/ldchang-peoplepoweredstream/index.html

Fill out form:
![screenshot 2017-03-09 01 24 04](https://cloud.githubusercontent.com/assets/328073/23738484/424492a6-0467-11e7-822d-c1f886a1dcfd.png)

Click Submit:
![screenshot 2017-03-09 01 25 05](https://cloud.githubusercontent.com/assets/328073/23738481/3f6bf4de-0467-11e7-8df2-2d2b8d3f3cfe.png)

Submitting:
![screenshot 2017-03-09 01 24 06](https://cloud.githubusercontent.com/assets/328073/23738466/1ea35b66-0467-11e7-9942-ebc7ff909e64.png)

5 second delay. Then resets.
![screenshot 2017-03-09 01 25 49](https://cloud.githubusercontent.com/assets/328073/23738496/59723b9a-0467-11e7-97ab-8c23123ef071.png)
