### PR TITLE
IE9 fix

### DIFF
--- a/stream/src/css/style.css
+++ b/stream/src/css/style.css
@@ -159,6 +159,7 @@ color:#FFF;
   position: absolute;
   left: 50%;
   top: 50%;
+  -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
   transition: opacity .2s;
 }


### PR DESCRIPTION
Forgot this vendor prefix to make the play button's centering work in IE9.