### PR TITLE
Add links to event host tools on /me screen

### DIFF
--- a/user_view.html
+++ b/user_view.html
@@ -29,6 +29,21 @@
 
         <div><a href="update/">Update your email or address.</a></div>
 
+        {% record '{"id": "' in user_dict %}
+        {% record actionkit_user.id in user_dict %}
+        {% record '"}' in user_dict %}
+        {% with user_dict|join:""|load_json as user_dict %}
+        {% withevents with "action" as campaign user_dict as host %}
+        {% if events %}
+        <h3>Events You're Hosting</h3>
+        <ul ckass="ak-margin-none">
+        {% for event in events %}
+          <li><a href="/event/action/{{ event.id }}/host">{{ event.title }} ({{ event.starts_at }})</a></li>
+        {% endfor %}
+        </ul>
+        {% endif %}
+        {% endwithevents %}
+        
         <h3> Subscription History </h3>
 
         <ul class="ak-margin-none">


### PR DESCRIPTION
After logging in or triggering a password reset, users will usually land on a go.peoplepower.org/me page which lists their profile info and subscription history.  By default it doesn't include any info about any events they've signed up to host.

This adds a "Events You're Hosting" section to the page, with links to the Host Tools screen so that they can manage their events / email attendees / etc.

(Right now I hardcoded it to only show events in the "action" campaign, but that could be parameterized if there's ever going to be more than that one campaign container.)