### PR TITLE
Add host-choosable categories for events

### DIFF
--- a/event_attendee_details.html
+++ b/event_attendee_details.html
@@ -8,6 +8,8 @@
 <!--         <p class="ak-event-title"><a href="/event/{{ campaign.local_name }}/{{event.id}}/signup/?akid={{args.akid}}&amp;zip={{args.zip}}">{{ event.title }}</a></p> -->
     {% endif %}
 
+      {% include "event_custom_field_categories.html" %}
+  <br>
 	<div class="subB">Location:</div>
 
     {% if event.venue %}

--- a/event_create.html
+++ b/event_create.html
@@ -106,6 +106,28 @@
                 </div>
             </div>
 
+            {% if templateset.custom_fields.event_categories %}
+            <div id="event-categories">
+              <h3>Event categories</h3>
+              {% with templateset.custom_fields.event_categories|load_json as categories_config %}
+              {% for category in categories_config %}
+              <div class="ak-err-below">
+                <input id="id_action_event_category_{{ category }}"
+                       class="checkbox" type="checkbox"
+                       name="action_event_category"
+                       value="{{ category }}"
+                       {% if event and event.custom_fields.category and event.custom_fields.category|force_list|contains:category %}checked{% endif %}
+                >
+                <label for="id_action_event_category_{{ category }}"
+                       class="ak-checkbox-label ak-event-category-checkbox-label">
+                  {{ categories_config|nth:category|nth:"label" }}
+                </label>
+              </div>
+              {% endfor %}
+              {% endwith %}
+            </div>
+            {% endif %}
+            
             <div id="event-info">
                 <h3>Event location</h3>
                 <div class="unknown_user">
@@ -267,6 +289,55 @@
 {% include "includes/jquery_ui.html" %}
 
 <script type="text/javascript">
+
+ actionkit.forms.prefill = function(overwrite) {
+     var forms = actionkit.forms, ak = actionkit;
+     // some event handlers want to change behavior during prefill (like
+     // maybe not fire). they can check actionkit.forms.prefilling.
+     forms.prefilling = true;
+     
+     var prefill_data = (
+         ( ak.context && ak.context.prefill_data )
+         ? ak.context.prefill_data
+         : ak.args
+     );
+     if ( prefill_data.form_name )
+         forms.setForm(prefill_data.form_name);
+     $(ak.form).deserialize(prefill_data, {overwrite: false});
+
+     // Check/uncheck boxes, which deserialize() won't do
+     $(ak.form).find('input:checkbox').each(function() {
+         if (prefill_data[this.name].constructor === Array) {
+             this.checked = $.inArray(this.value, prefill_data[this.name]) !== -1;
+         } else {
+             this.checked = prefill_data[this.name] == this.value ? true : false;
+         }
+     })
+
+     // checking for true, not just present
+     if ( prefill_data['amount_other'] ) {
+         $(ak.form).find('input.amount_radio_button').attr('checked', false)
+         $(ak.form).find('input[name=amount_other]').click()
+     }
+
+     // fire onchange and onclick, for in-field labels etc.
+     // unfortunately #id_subscription_consent's onchange turns on
+     // suppress_subscribe, so leave it out.
+     $(ak.form).find(':input:not(#id_subscription_consent)').change();
+     $(ak.form).find(':input:checked').each(function(){
+         // trigger radio handler used by donate form amount buttons
+         // for checkboxes we just checked, click() would uncheck them
+         if (this.type.toLowerCase() != 'checkbox')
+             $(this).click();
+         $(this).change();
+     });
+
+     // the change events forced above hide errors; show them again
+     forms.handleQueryStringErrors()
+
+     forms.prefilling = false;
+ }
+ 
     isEventUnitedStates = function () {
         var country = actionkit.form && actionkit.form.event_country
         && actionkit.utils.val(actionkit.form.event_country)

--- a/event_custom_field_categories.html
+++ b/event_custom_field_categories.html
@@ -1,0 +1,8 @@
+{% if templateset.custom_fields.event_categories and event.custom_fields.event_category %}
+<div class="ak-event-categories">
+{% for category in event.custom_fields.event_category|force_list %}
+<strong>{{ templateset.custom_fields.event_categories|load_json|nth:category|nth:"label"|default:category }}</strong>
+{% if not forloop.last %}•{% endif %}
+{% endfor %}
+</div>
+{% endif %}

--- a/event_host_details.html
+++ b/event_host_details.html
@@ -47,6 +47,8 @@
     </tr>
 </table>
 
+{% include "event_custom_field_categories.html" %}
+
 {% if event.public_description %}
     <p class="ak-event-description">
         {{ event.public_description }}

--- a/event_search_results.html
+++ b/event_search_results.html
@@ -88,6 +88,8 @@
 </div>
 {% endif %}
 
+{% include "event_custom_field_categories.html" %}
+
 <!--
                 <table cellspacing="0" class="ak-event-table">
                         <tr class="ak-event-time">

--- a/wrapper.html
+++ b/wrapper.html
@@ -48,7 +48,9 @@
     {% end %}
 
     <style>
-    
+     .ak-labels-before label.ak-event-category-checkbox-label {
+         top: -5px;
+     }
     </style>
     {% block script_additions %}{% endblock %}
 


### PR DESCRIPTION
* The set of category choices (and the existence of the feature) is configured
  with a custom templateset field that's stored as a json blob like
  `{"muslimban": {"label": "Muslim Ban"}, "freedomcities": "Freedom Cities"}`

* Host can then choose categories via checkboxes on event creation / edit forms

* Host's chosen categorie(s) will be stored in custom event fields

* If set, categories will be displayed on rsvp/signup form, attendee tools,
  search results, and host tools pages

## Creation
<img width="1059" alt="screen shot 2017-03-16 at 10 03 56 pm" src="https://cloud.githubusercontent.com/assets/54995/24026255/2a0d0148-0a96-11e7-8c0e-f0ac32510022.png">

## Host Tools
<img width="1011" alt="screen shot 2017-03-16 at 10 03 47 pm" src="https://cloud.githubusercontent.com/assets/54995/24026257/2a1062d4-0a96-11e7-9241-960c9a16cabf.png">

## Signup Form
<img width="1033" alt="screen shot 2017-03-16 at 10 02 26 pm" src="https://cloud.githubusercontent.com/assets/54995/24026256/2a0e251e-0a96-11e7-8ddc-866cdc4c8fb7.png">

## Attendee Tools
<img width="1030" alt="screen shot 2017-03-16 at 10 02 41 pm" src="https://cloud.githubusercontent.com/assets/54995/24026258/2a148288-0a96-11e7-8e7b-e8180eb3b123.png">

