### PR TITLE
Events description

### DIFF
--- a/event_attendee_details.html
+++ b/event_attendee_details.html
@@ -62,7 +62,7 @@
     {% if event.public_description %}
         <div class="ak-event-description">
 		<div class="subB">Description:</div>
-            {{ event.public_description|linebreaksbr }}
+            {{ event.public_description|linebreaks }}
         </div>
     {% endif %}
 

--- a/event_attendee_details.html
+++ b/event_attendee_details.html
@@ -62,7 +62,7 @@
     {% if event.public_description %}
         <div class="ak-event-description">
 		<div class="subB">Description:</div>
-            {{ event.public_description }}
+            {{ event.public_description|linebreaksbr }}
         </div>
     {% endif %}
 

--- a/event_host_details.html
+++ b/event_host_details.html
@@ -51,7 +51,7 @@
 
 {% if event.public_description %}
     <p class="ak-event-description">
-        {{ event.public_description|linebreaksbr }}
+        {{ event.public_description|linebreaks }}
     </p>
 {% endif %}
 

--- a/event_host_details.html
+++ b/event_host_details.html
@@ -51,7 +51,7 @@
 
 {% if event.public_description %}
     <p class="ak-event-description">
-        {{ event.public_description }}
+        {{ event.public_description|linebreaksbr }}
     </p>
 {% endif %}
 

--- a/event_search_results.html
+++ b/event_search_results.html
@@ -112,7 +112,7 @@
                 {% if campaign.show_public_description %}
                     {% if event.public_description %}
                         <p class="ak-event-description">
-                            {{ event.public_description }}
+                            {{ event.public_description|linebreaksbr }}
                         </p>
                     {% endif %}
                 {% endif %}

--- a/event_search_results.html
+++ b/event_search_results.html
@@ -112,7 +112,7 @@
                 {% if campaign.show_public_description %}
                     {% if event.public_description %}
                         <p class="ak-event-description">
-                            {{ event.public_description|linebreaksbr }}
+                            {{ event.public_description|linebreaks }}
                         </p>
                     {% endif %}
                 {% endif %}


### PR DESCRIPTION
Allow users to enter line breaks in events descriptions.

Note that if we eventually want to add the urlize filter, it needs to go before linebreaks