### PR TITLE
Add custom templateset field for customization in the user form section on the event_attend page

### DIFF
--- a/event_attend.html
+++ b/event_attend.html
@@ -72,7 +72,10 @@
                             <p>Need to sign up with another email address?  <a href="?" onclick="window.actionkit.args = {}; return actionkit.forms.logOut()">Click here.</a></p>
                         </div>
                         {% endif %}
-
+                        <!-- Allow for customization for a given event on the signup form -->
+                        {% if templateset.custom_fields.event_user_form_code %}
+                            {% include_tmpl templateset.custom_fields.event_user_form_code %}
+                        {% endif %}
                     </div>
             
                     {% if form.ground_rules|is_nonblank and not update %}


### PR DESCRIPTION
Add a way to manipulate the event signup form based on a custom
templateset field.
Gives the ability to do things like show certain questions for certain
event IDs without editing the templateset code; just updating a
templateset field. (request from Lillie)