### PR TITLE
Enable social share step 3 config, share tracking, and share content a/b-testability for event pages

### DIFF
--- a/event_attend.html
+++ b/event_attend.html
@@ -103,10 +103,20 @@
                     </div>
                 </div>   
                 <div class="event-share">
-		<div class="subA">Share</div>
-	   <div class="thanks-share-fb"><a class="buttonA3 icon-fb" href="https://www.facebook.com/sharer/sharer.php?u=https://go.peoplepower.org/event/{{ campaign.local_name }}/{{event.id}}/signup/?source=fbshare" target="_blank"><span class="box"><span class="icon"></span>Post to Facebook</a></span></div>
-<div class="thanks-share-twitter"><a class="buttonA3 icon-twitter" href="https://twitter.com/home?status=Join%20me%20for%20an%20%40ACLU%20People%20Power%20Action%20Event%20in%20{{ event.city_etc_no_postal }}%20https%3A//go.peoplepower.org/event/{{campaign.local_name}}/{{event.id}}/signup/?source=twshare" target="_blank"><span class="box"><span class="icon"></span>Share on Twitter</a></span></div>
-	</div>        
+		  <div class="subA">Share</div>
+	          <div class="thanks-share-fb">
+                    <a class="buttonA3 icon-fb ak-facebook"
+                       href="/share/link?type=fb&amp;page_name={{ event.campaign.signup_page.name }}&amp;append=../{{ event.id }}&amp;action_id={{action.id}}&amp;akid={{akid}}" target="_blank">
+                      <span class="box"><span class="icon"></span>Post to Facebook</a></span>
+                  </div>
+
+                  <div class="thanks-share-twitter">
+                    <a class="buttonA3 icon-twitter ak-twitter"
+                       href="/share/link?type=tw&amp;page_name={{ event.campaign.signup_page.name }}&amp;append=../{{ event.id }}&amp;action_id={{action.id}}&amp;akid={{akid}}&amp;tweet={% if page.followup.twitter_message %}{% include_tmpl page.followup.twitter_message %}{% else %}Join me for an @ACLU People Power Action Event in {{ event.city_etc_no_postal }}{% endif %}" target="_blank">
+                      <span class="box"><span class="icon"></span>Share on Twitter</a></span>
+                  </div>
+
+	        </div>
             </div>
         </div>
 <div class="ak-grid-row">

--- a/event_attendee_tools.html
+++ b/event_attendee_tools.html
@@ -62,14 +62,23 @@ function scrollToAnchor(aid){
 	        {% include "./event_invite.html" %}
 	    {% endif %}
 	</div>
-	<div class="event-share">
-		<div class="subA">Share</div>
-    
-    <div class="thanks-share-fb"><a class="buttonA3 icon-fb" href="https://www.facebook.com/sharer/sharer.php?u=https://go.peoplepower.org/event/{{ campaign.local_name }}/{{event.id}}/signup/?source=fbshare" target="_blank"><span class="box"><span class="icon"></span>Post to Facebook</a></span></div>
-<div class="thanks-share-twitter"><a class="buttonA3 icon-twitter" href="https://twitter.com/home?status=Join%20me%20for%20an%20%40ACLU%20People%20Power%20Action%20Event%20in%20{{ event.city_etc_no_postal }}%20https%3A//go.peoplepower.org/event/{{campaign.local_name}}/{{event.id}}/signup/?source=twshare" target="_blank"><span class="box"><span class="icon"></span>Share on Twitter</a></span></div>
-    
-	
-	</div> <!-- .event-share -->
+
+        <div class="event-share">
+	  <div class="subA">Share</div>
+	  <div class="thanks-share-fb">
+            <a class="buttonA3 icon-fb ak-facebook"
+               href="/share/link?type=fb&amp;page_name={{ event.campaign.signup_page.name }}&amp;append=../{{ event.id }}&amp;action_id={{action.id}}&amp;akid={{akid}}" target="_blank">
+              <span class="box"><span class="icon"></span>Post to Facebook</a></span>
+          </div>
+
+          <div class="thanks-share-twitter">
+            <a class="buttonA3 icon-twitter ak-twitter"
+               href="/share/link?type=tw&amp;page_name={{ event.campaign.signup_page.name }}&amp;append=../{{ event.id }}&amp;action_id={{action.id}}&amp;akid={{akid}}&amp;tweet={% if page.followup.twitter_message %}{% include_tmpl page.followup.twitter_message %}{% else %}Join me for an @ACLU People Power Action Event in {{ event.city_etc_no_postal }}!{% endif %}" target="_blank">
+              <span class="box"><span class="icon"></span>Share on Twitter</a></span>
+          </div>
+
+	</div>
+
 </div> <!-- col6 -->
 
 </div> <!-- .ak-grid-row -->

--- a/event_host_tools.html
+++ b/event_host_tools.html
@@ -215,10 +215,27 @@
                         <li><a confirm-message="Really cancel event? This can't be undone." href="/event/{{ campaign.local_name }}/{{ event.id }}/cancel_event/">Cancel event</a></li>
                         <li><a href="/logout/">Log out</a></li>
                     </ul>
+
+                    <div class="event-share">
+		      <div class="subA">Share</div>
+	              <div class="thanks-share-fb">
+                        <a class="buttonA3 icon-fb ak-facebook"
+                           href="/share/link?type=fb&amp;page_name={{ event.campaign.signup_page.name }}&amp;append=../{{ event.id }}&amp;action_id={{action.id}}&amp;akid={{akid}}" target="_blank">
+                          <span class="box"><span class="icon"></span>Post to Facebook</a></span>
+                      </div>
+                      
+                      <div class="thanks-share-twitter">
+                        <a class="buttonA3 icon-twitter ak-twitter"
+                           href="/share/link?type=tw&amp;page_name={{ event.campaign.signup_page.name }}&amp;append=../{{ event.id }}&amp;action_id={{action.id}}&amp;akid={{akid}}&amp;tweet={% if page.followup.twitter_message %}{% include_tmpl page.followup.twitter_message %}{% else %}Join me for an @ACLU People Power Action Event in {{ event.city_etc_no_postal }}{% endif %}" target="_blank">
+                          <span class="box"><span class="icon"></span>Share on Twitter</a></span>
+                      </div>
+                      
+	            </div>                    
                 </div>
+                
             </div><!-- bar holder -->
         </div><!-- span -->
-
+        
         <div class="ak-grid-col ak-grid-col-8-of-12">
             <!-- Details -->
             <div id="host-event-details ak-clearfix">

--- a/wrapper.html
+++ b/wrapper.html
@@ -15,23 +15,30 @@
 <meta name="application-name" content="People Power"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge;chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-	{% if event.is_open_for_signup %}
-		<title>People Power Action Event in {{ event.city_etc_no_postal }}</title>
-		<meta property="og:image" content="https://s3.amazonaws.com/s3.peoplepower.org/images/aclu-rsvpnow.png" />
-		<meta property="og:title" content="Join a People Power Action Event in {{ event.city_etc_no_postal }}" />
-		<meta name="description" property="og:description" content="We're organizing grassroots volunteers to fight for civil rights and liberties.">
-		<meta property="og:site_name" content="PeoplePower.org">
-		<meta name="twitter:card" value="summary_large_image">
+    {% if event.is_open_for_signup %}
+    <title>People Power Action Event in {{ event.city_etc_no_postal }}</title>
     {% else %}
-		<title>{% block title %}{{ page.title }} | {% filter ak_text:"org_name" %}{% client_name %}{% endfilter %}{% endblock %}</title>
-		{{ page.followup.share_title_tag }}
-		{% if form.id %}<meta name="description" property="og:description" content="{% block description %}{{ page.followup.share_description_value }}{% endblock %}">{% endif %}
-		{{ page.followup.share_image_tag }}
-		{{ page.followup.share_url_tag }}
-		<meta property="og:site_name" content="{% filter ak_text:"org_name" %}{% client_name %}{% endfilter %}">
-		<meta property="og:type" content="article">
-		<meta name="twitter:card" value="summary_large_image">    	
+    <title>{% block title %}{{ page.title }} | {% filter ak_text:"org_name" %}{% client_name %}{% endfilter %}{% endblock %}</title>
+    <meta property="og:type" content="article">
     {% endif %}
+
+    <meta property="og:title" content="{% if page.followup.share_title_value %}{% include_tmpl page.followup.share_title_value %}{% elif event.is_open_for_signup %}Join a People Power Action Event in {{ event.city_etc_no_postal }}{% else %}{{ page.title }}{% endif %}" />
+
+    {% if page.followup.share_image_value %}
+    {{ page.followup.share_image_tag }}
+    {% elif event.is_open_for_signup %}
+    <meta property="og:image" content="https://s3.amazonaws.com/s3.peoplepower.org/images/aclu-rsvpnow.png" />
+    {% endif %}
+    
+    {% if form.id %}
+    <meta name="description" property="og:description"
+          content="{% block description %}{% if page.followup.share_description_value %}{% include_tmpl page.followup.share_description_value %}{% else %}We're organizing grassroots volunteers to fight for civil rights and liberties.{% endif %}{% endblock %}">
+    {% endif %}
+    
+    {{ page.followup.share_url_tag }}
+    <meta property="og:site_name" content="{% filter ak_text:"org_name" %}{% client_name %}{% endfilter %}">
+    <meta name="twitter:card" value="summary_large_image">
+
     <meta name="twitter:site" content="@ACLU">
     <meta name="twitter:creator" content="@ACLU">
     {% block meta_additions %}{% endblock %}


### PR DESCRIPTION
* Add fb/tw buttons to host tools page

* Switch signup and attendee tools pages to use internal /share links
  instead of directly building the share content on the buttons

* Use ?tweet param in tw button, filled in with content rendered as
  template from step 3 share config -- otherwise step 3 share config
  would be unable to use things like {{ event.city_etc_no_postal }}.

* Build og title and description tags in wrapper by hand from step 3
  share config, instead of using the AK helpers to write out the tags,
  in order to render those values as templates with per-event info also

* Set default values for tweet text and fb title/description/image
  so that event campaigns without config set yet won't revert to none